### PR TITLE
Updated STEPPER_ENABLE_PIN

### DIFF
--- a/Everything/pin_config.h
+++ b/Everything/pin_config.h
@@ -16,7 +16,11 @@
 #ifndef DIR_PIN
 #define DIR_PIN         3
 #endif
-// #define STEPPER_ENABLE_PIN  22  // Uncomment if your driver has an enable pin
+// Uncomment STEPPER_ENABLE_PIN if stepper uses an enable pin 
+// (required for user reset button w/ maintenance mode)
+#ifndef STEPPER_ENABLE_PIN      
+#define STEPPER_ENABLE_PIN  49  
+#endif                         
 
 // =====================================================
 // RELAY PIN
@@ -67,7 +71,7 @@
 #endif
 
 // =====================================================
-// PINSETTER RESET PIN
+// PINSETTER RESET (BUTTON) PIN
 // =====================================================
 #ifndef PINSETTER_RESET_PIN
 #define PINSETTER_RESET_PIN 41


### PR DESCRIPTION
We may not want this turned on as default, but if we need it, this is what I think it should look like.
The enable pin is required for maintenance mode used by the 'button reset' in order to free spin the turret.