### PR TITLE
Fix Turret Jam During Strike

### DIFF
--- a/Everything/Everything.ino
+++ b/Everything/Everything.ino
@@ -1209,7 +1209,20 @@ void updateSweepTween(){
 void waitSweepDone(unsigned long timeoutMs){
   unsigned long start=millis();
   while(sweepAnimating && (millis()-start)<timeoutMs){
-    updateSweepTween(); delay(1);
+	// Keep background mechanisms alive while sweep motion completes.
+    // This prevents turret/conveyor catch logic from stalling during
+    // long strike sweep animations.
+    runTurret();
+    updateConveyorOutput();
+    updateBallReturnDoor();
+    updateSweepTween();
+    laneUpdate();
+    if(millis()-prevScoreMillis>=SCORE_INTERVAL){
+      prevScoreMillis=millis();
+      checkSerial();
+      checkInputChanges();
+    }
+    delay(1);
   }
   if(sweepAnimating){
     sweepCurL=sweepTargetL; sweepCurR=sweepTargetR;

--- a/Everything/Everything.ino
+++ b/Everything/Everything.ino
@@ -66,6 +66,7 @@ unsigned long ballCometStartMs=0, ballCometLastFrame=0;
 void ledsBegin(); void deckAll(uint32_t col); void laneAll(uint32_t col); void ledsShowAll(); void laneShowOnly();
 void laneUpdate(); void startStrikeWipe(); void startStrikeFlash(); void startBallCometImmediate();
 void endAllLaneAnimsToWhite(); void startupWipeWhiteQuick();
+void handleConfirmedBall(unsigned long now);
 
 // NEW: frame LED helpers
 void updateFrameLEDs();
@@ -104,6 +105,7 @@ Servo LeftRaiseServo, RightRaiseServo, SlideServo, ScissorsServo, LeftSweepServo
 
 // ======================= PAUSE MODE =======================
 bool pauseMode = false;
+bool queuedBallDuringSet = false;
 unsigned long lastBallActivityMs = 0;
 
 // Track sweep pose so we can reliably check "sweep is up"
@@ -412,33 +414,17 @@ void loop(){
   if(rawBall==LOW && ballPrev==HIGH){ ballPending=true; ballLowStartUs=micros(); }
   if(ballPending){
     if(rawBall==LOW){
-      if((micros()-ballLowStartUs)>=BALL_LOW_CONFIRM_US && waitingForBall && ballRearmed){
+   if((micros()-ballLowStartUs)>=BALL_LOW_CONFIRM_US && ballRearmed){
 
-        // If paused and a ball arrives anyway, immediately resume (fail-safe)
-        if(pauseMode){
-          exitPauseMode();
-        }
-
-        waitingForBall=false;
-        lastBallActivityMs = millis();   // NEW: refresh idle timer on ball
-        scoreWindowActive=true;
-
-        scoremoreBallPulse_begin();
-
-        startBallCometImmediate();
-        onBallThrownDoorClose();
-
-        lastPinCatchMs = millis();
-
-        if (inFillBall) {
-          stepIndex = 22;
-          fillBallShotInProgress = true;
-        } else {
-          stepIndex = (throwCount==1) ? 1 : 22;
-        }
-
-        if(throwCount==1){ forceConveyorForBallReturn=true; }
-        prevStepMillis=now; ballRearmed=false; lastBallHighMs=millis(); ballPending=false;
+        if(waitingForBall && ballRearmed){
+          handleConfirmedBall(now);
+          ballRearmed=false; lastBallHighMs=millis(); ballPending=false;
+        }else if(ballRearmed && stepIndex>=32 && stepIndex<=36){
+          // Accept a throw during the post-set finish sequence and
+          // fire it as soon as the machine returns to ready state.
+          queuedBallDuringSet=true;
+          ballRearmed=false; lastBallHighMs=millis(); ballPending=false;
+        }   
       }
     }else{ ballPending=false; }
   }
@@ -456,6 +442,34 @@ void loop(){
 }
 
 // ======================= SEQUENCER =======================
+void handleConfirmedBall(unsigned long now){
+  // If paused and a ball arrives anyway, immediately resume (fail-safe)
+  if(pauseMode){
+    exitPauseMode();
+  }
+
+  waitingForBall=false;
+  lastBallActivityMs = millis();    // NEW: refresh idle timer on ball
+  scoreWindowActive=true;
+
+  scoremoreBallPulse_begin();
+
+  startBallCometImmediate();
+  onBallThrownDoorClose();
+
+  lastPinCatchMs = millis();
+
+  if (inFillBall) {
+    stepIndex = 22;
+    fillBallShotInProgress = true;
+  } else {
+    stepIndex = (throwCount==1) ? 1 : 22;
+  }
+
+  if(throwCount==1){ forceConveyorForBallReturn=true; }
+  prevStepMillis=now;
+}
+
 void runSequence(){
   unsigned long now=millis();
   unsigned long need=stepDuration(stepIndex);
@@ -545,8 +559,9 @@ void runSequence(){
     forceConveyorForBallReturn=false;
     dropCycleJustFinished=false;
     deckHasTenReady=false;
-    strikeDetected=false; 
-    strikePending=false;
+    // Do not clear an already-detected strike here: scoring can report
+    // strike before reset/set completion fully exits.
+    if(!strikeDetected) strikePending=false;
 
     if (fillBallShotInProgress) {
       autoResetFillBall = false;
@@ -557,6 +572,18 @@ void runSequence(){
 
     throwCount=1; waitingForBall=true;
     updateFrameLEDs();
+	
+	 // If a ball was thrown during post-set completion, process it now.
+    if(queuedBallDuringSet){
+      queuedBallDuringSet=false;
+      handleConfirmedBall(millis());
+      ballRearmed=false;
+      lastBallHighMs=millis();
+      ballPending=false;
+      prevStepMillis=millis();
+      return;
+    }
+	
     stepIndex=0; prevStepMillis=millis(); return;
   }
 

--- a/Everything/Everything.ino
+++ b/Everything/Everything.ino
@@ -767,8 +767,8 @@ void runTurret(){
   }
   if(irStableState==HIGH) pinEdgeArmed=true;
 
-  // Queue pin hits whenever we're not in dwell/hold AND not paused (NEW)
-  if(!pauseMode && !releaseDwellActive && !conesFullHold){
+  // Queue pin hits whenever we're not in dwell/hold/release-transfer AND not paused
+  if(!pauseMode && !releaseDwellActive && !conesFullHold && !(turretReleaseRequested && (targetPos==Pin10ReleasePos()))){
     if(pinEdgeArmed && irStableState==LOW){
       queuedPinEvents++;         // record that one more pin has arrived
       pinEdgeArmed = false;      // wait for beam to clear before next
@@ -849,7 +849,11 @@ void onPinDetected(){
       return;
     }
     if( (turretReleaseRequested || (deckIsUp && backgroundRefillRequested)) ){
-      turretReleaseRequested=true; goTo(Pin10ReleasePos()); return;
+       turretReleaseRequested=true;
+      queuedPinEvents=0;    // reject extra pin edges while releasing the 10th
+      pinEdgeArmed=false;
+      goTo(Pin10ReleasePos());
+      return;
     }
     pinEdgeArmed=false; return;
   }
@@ -954,6 +958,10 @@ void updateConveyorOutput(){
 
   if(conveyorLockedByDwell){
     if(millis()-releaseDwellStart<RELEASE_FEED_ASSIST_MS) ConveyorOn();  else ConveyorOff();
+    return;
+  }
+    if(turretReleaseRequested && !releaseDwellActive && (targetPos==Pin10ReleasePos())){
+    ConveyorOff();
     return;
   }
   if(suspendConveyorUntilHomeDone){ ConveyorOff(); return; }

--- a/Everything/general_config.h
+++ b/Everything/general_config.h
@@ -125,16 +125,16 @@
 // =====================================================
 // Defaults are listed on settings that are commonly adjusted.
 #ifndef TURRET_NORMAL_MAXSPEED
-#define TURRET_NORMAL_MAXSPEED  650.0
+#define TURRET_NORMAL_MAXSPEED  800.0
 #endif
 #ifndef TURRET_NORMAL_ACCEL
-#define TURRET_NORMAL_ACCEL     3000.0
+#define TURRET_NORMAL_ACCEL     3800.0
 #endif
 #ifndef TURRET_SPRING_MAXSPEED
-#define TURRET_SPRING_MAXSPEED  300.0
+#define TURRET_SPRING_MAXSPEED  380.0
 #endif
 #ifndef TURRET_SPRING_ACCEL
-#define TURRET_SPRING_ACCEL     1500.0
+#define TURRET_SPRING_ACCEL     2000.0
 #endif
 
 // Home position adjuster (fine-tune after homing).
@@ -189,7 +189,7 @@
 #define PIN_POS_9       -1467
 #endif
 #ifndef PIN_POS_10
-#define PIN_POS_10      -1600
+#define PIN_POS_10      -1580
 #endif
 
 // =====================================================


### PR DESCRIPTION
Keep background mechanisms alive while sweep motion completes. This prevents turret/conveyor catch logic from stalling during long strike sweep animations.